### PR TITLE
Config auto creation added

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -1,6 +1,6 @@
 #include "Config.h"
 
-#include <Poco/Foundation.h>
+#include <Poco/Util/PropertyFileConfiguration.h>
 #include <iostream>
 #include <fstream>
 #include <cstring>

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -1,30 +1,40 @@
 #include "Config.h"
 
-#include <Poco/Util/PropertyFileConfiguration.h>
 #include <Poco/Foundation.h>
 #include <iostream>
+#include <fstream>
+#include <cstring>
 
 
 
-Poco::UInt16 serverPort = 80;
+Poco::UInt16 serverPort = 8080;
+#define SERVER_PORT_KEY "serverPort"
 Poco::UInt32 serverMaxQueued = 128;
+#define SERVER_MAX_QUEUED_KEY "serverMaxQueued"
 Poco::UInt32 serverMaxThreads = 16;
+#define SERVER_MAX_THREADS "serverMaxThreads"
 
-void Config::loadConfig(std::string path)
+bool createConfigFile(std::string path);
+void loadConfig(std::string);
+unsigned int getUIntFromConf(
+	Poco::AutoPtr<Poco::Util::PropertyFileConfiguration> pConf,
+	std::string key,
+	unsigned int defaultValue);
+
+
+void Config::initConfig(int argc, char **argv)
 {
-	try
-	{
-		Poco::AutoPtr<Poco::Util::PropertyFileConfiguration> pConf;
-		pConf = new Poco::Util::PropertyFileConfiguration(path);
+	std::string configFilePath = "OGaBox.cfg";
 
-		serverPort = pConf->getUInt("serverPort");
-		serverMaxQueued = pConf->getUInt("serverMaxQueued");
-		serverMaxThreads = pConf->getUInt("serverMaxThreads");
-	}
-	catch (...)
+	for(int i = 1; i < argc-1; i++)
 	{
-		std::cerr << "Config file '" << path << "' not found!" << std::endl;
+		if(strcmp("-c", argv[i]) == 0 || strcmp("--config", argv[i]) == 0)
+		{
+			configFilePath = argv[i+1];
+		}
 	}
+
+	loadConfig(configFilePath);
 }
 
 Poco::UInt16 Config::getServerPort()
@@ -40,4 +50,69 @@ Poco::UInt32 Config::getMaxQueued()
 Poco::UInt32 Config::getMaxThreads()
 {
 	return serverMaxThreads;
+}
+
+void loadConfig(std::string path)
+{
+	std::ifstream confFile(path.c_str());
+	bool fileExists = confFile.good();
+	confFile.close();
+
+	if(fileExists)
+	{
+		Poco::AutoPtr<Poco::Util::PropertyFileConfiguration> pConf;
+		pConf = new Poco::Util::PropertyFileConfiguration(path);
+
+		serverPort = getUIntFromConf(pConf, SERVER_PORT_KEY, serverPort);
+		serverMaxQueued = getUIntFromConf(pConf, SERVER_MAX_QUEUED_KEY, serverMaxQueued);
+		serverMaxThreads = getUIntFromConf(pConf, SERVER_MAX_THREADS, serverMaxThreads);
+	}
+	else
+	{
+		std::cerr << "Config file '" << path << "' does not exist" << std::endl;
+
+		if(createConfigFile(path))
+		{
+			std::cout << "Config file '" << path << "' was created with default values."
+					<< std::endl;
+		}
+	}
+}
+
+unsigned int getUIntFromConf(
+		Poco::AutoPtr<Poco::Util::PropertyFileConfiguration> pConf,
+		std::string key,
+		unsigned int defaultValue)
+{
+	unsigned int value = 0;
+
+	try
+	{
+		value = pConf->getUInt(key);
+	}
+	catch (...)
+	{
+		value = defaultValue;
+		std::cerr << "Config file does not contain a '" << key << "' value." << std::endl;
+	}
+
+	return value;
+}
+
+bool createConfigFile(std::string path)
+{
+    Poco::AutoPtr<Poco::Util::PropertyFileConfiguration> pConf;
+	pConf = new Poco::Util::PropertyFileConfiguration();
+
+	pConf->setUInt(SERVER_PORT_KEY, serverPort);
+	pConf->setUInt(SERVER_MAX_QUEUED_KEY, serverMaxQueued);
+	pConf->setUInt(SERVER_MAX_THREADS, serverMaxThreads);
+
+	pConf->save(path);
+
+	std::ifstream confFile(path.c_str());
+	bool fileExists = confFile.good();
+	confFile.close();
+
+	return fileExists;
 }

--- a/src/Config.h
+++ b/src/Config.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Poco/Util/PropertyFileConfiguration.h>
 #include <Poco/Foundation.h>
 #include <string>
 
@@ -7,7 +8,8 @@
 
 namespace Config
 {
-	void loadConfig(std::string);
+	void initConfig(int argc, char **argv);
+
 	Poco::UInt16 getServerPort();
 	Poco::UInt32 getMaxQueued();
 	Poco::UInt32 getMaxThreads();

--- a/src/Config.h
+++ b/src/Config.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <Poco/Util/PropertyFileConfiguration.h>
 #include <Poco/Foundation.h>
-#include <string>
 
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,15 +2,15 @@
 #include <Poco/Net/HTTPServer.h>
 #include <Poco/Net/ServerSocket.h>
 #include <iostream>
-#include "Config.h"
 
+#include "Config.h"
 #include "OGaRequestHandlerFactory.h"
 
 
 
 int main(int argc, char **argv)
 {
-	Config::loadConfig("OGaBox.cfg");
+	Config::initConfig(argc, argv);
 	std::cout << "OGaBox!Service v0.0" << std::endl;
 	Poco::UInt16 port = Config::getServerPort();
 	std::cout << "port: " << port << std::endl;


### PR DESCRIPTION
You can now use the parameters "-c" or "--config" to specify a configuration file-path. On default "OGaBox.cfg" will be used. If no configfile exists a new one will be created and stored at this destination.
